### PR TITLE
Changes for focus groups

### DIFF
--- a/src/components/Headers/Header.js
+++ b/src/components/Headers/Header.js
@@ -23,7 +23,7 @@ class Header extends React.Component {
                             tag="h5"
                             className="text-uppercase text-muted mb-0"
                           >
-                            Stress Score
+                            Miles Walked
                           </CardTitle>
                           <span className="h2 font-weight-bold mb-0">
                             {this.props.overalls["stress"] && this.props.overalls["stress"]["score"]}
@@ -39,9 +39,9 @@ class Header extends React.Component {
                         {this.props.overalls["stress"] && this.props.overalls["stress"]["value_change"] === "up" ?
                           (<span className="text-danger mr-2">
                             <i className="fa fa-arrow-up" /> {this.props.overalls["stress"]["percent_change"]}%
-                          </span>) 
-                          : 
-                          (<span className="text-success mr-2">
+                          </span>)
+                          :
+                          (<span className="text-danger mr-2">
                             <i className="fa fa-arrow-down" /> {this.props.overalls["stress"] && this.props.overalls["stress"]["percent_change"]}%
                           </span>)
                           }{" "}
@@ -75,8 +75,8 @@ class Header extends React.Component {
                         {this.props.overalls["sleep"] && this.props.overalls["sleep"]["value_change"] === "up" ?
                           (<span className="text-success mr-2">
                             <i className="fa fa-arrow-up" /> {this.props.overalls["sleep"]["percent_change"]}%
-                          </span>) 
-                          : 
+                          </span>)
+                          :
                           (<span className="text-danger mr-2">
                             <i className="fa fa-arrow-down" /> {this.props.overalls["sleep"] && this.props.overalls["sleep"]["percent_change"]}%
                           </span>)
@@ -95,7 +95,7 @@ class Header extends React.Component {
                             tag="h5"
                             className="text-uppercase text-muted mb-0"
                           >
-                            Stress Management
+                            Social Activity
                           </CardTitle>
                           <span className="h2 font-weight-bold mb-0">
                             {this.props.overalls["stress_management"] && this.props.overalls["stress_management"]["score"]} mins/day
@@ -111,8 +111,8 @@ class Header extends React.Component {
                         {this.props.overalls["stress_management"] && this.props.overalls["stress_management"]["value_change"] === "up" ?
                           (<span className="text-success mr-2">
                             <i className="fa fa-arrow-up" /> {this.props.overalls["stress_management"]["percent_change"]}%
-                          </span>) 
-                          : 
+                          </span>)
+                          :
                           (<span className="text-danger mr-2">
                             <i className="fa fa-arrow-down" /> {this.props.overalls["stress_management"] && this.props.overalls["stress_management"]["percent_change"]}%
                           </span>)
@@ -122,7 +122,7 @@ class Header extends React.Component {
                     </CardBody>
                   </Card>
                 </Col>
-                <Col lg="6" xl="3">
+                {/* <Col lg="6" xl="3">
                   <Card className="card-stats mb-4 mb-xl-0">
                     <CardBody>
                       <Row>
@@ -147,8 +147,8 @@ class Header extends React.Component {
                         {this.props.overalls["stress_events"] && this.props.overalls["stress_events"]["value_change"] === "up" ?
                           (<span className="text-danger mr-2">
                             <i className="fa fa-arrow-up" /> {this.props.overalls["stress_events"]["percent_change"]}%
-                          </span>) 
-                          : 
+                          </span>)
+                          :
                           (<span className="text-success mr-2">
                             <i className="fa fa-arrow-down" /> {this.props.overalls["stress_events"] && this.props.overalls["stress_events"]["percent_change"]}%
                           </span>)
@@ -157,7 +157,7 @@ class Header extends React.Component {
                       </p>
                     </CardBody>
                   </Card>
-                </Col>
+                </Col> */}
               </Row>
             </div>
           </Container>

--- a/src/components/Headers/Header.js
+++ b/src/components/Headers/Header.js
@@ -45,7 +45,7 @@ class Header extends React.Component {
                             <i className="fa fa-arrow-down" /> {this.props.overalls["stress"] && this.props.overalls["stress"]["percent_change"]}%
                           </span>)
                           }{" "}
-                        <span className="text-nowrap">Since last week</span>
+                        <span className="text-nowrap">Last seven days</span>
                       </p>
                     </CardBody>
                   </Card>
@@ -81,7 +81,7 @@ class Header extends React.Component {
                             <i className="fa fa-arrow-down" /> {this.props.overalls["sleep"] && this.props.overalls["sleep"]["percent_change"]}%
                           </span>)
                           }{" "}
-                        <span className="text-nowrap">Since last week</span>
+                        <span className="text-nowrap">Last seven days</span>
                       </p>
                     </CardBody>
                   </Card>
@@ -117,7 +117,7 @@ class Header extends React.Component {
                             <i className="fa fa-arrow-down" /> {this.props.overalls["stress_management"] && this.props.overalls["stress_management"]["percent_change"]}%
                           </span>)
                           }{" "}
-                        <span className="text-nowrap">Since last week</span>
+                        <span className="text-nowrap">Last seven days</span>
                       </p>
                     </CardBody>
                   </Card>

--- a/src/variables/charts_data.js
+++ b/src/variables/charts_data.js
@@ -643,7 +643,7 @@ let activity_pie = {
 
   data1: canvas => {
       return {
-      labels: ["Running", "Walking", "Sitting", "Driving"],
+      labels: ["Running", "Walking", "Sitting", "In a vehicle"],
       datasets: [
           {
           label: "Breakdown by activity name in the past day",
@@ -661,7 +661,7 @@ let activity_pie = {
 
   data2: canvas => {
       return {
-      labels: ["Running", "Walking", "Sitting", "Driving"],
+      labels: ["Running", "Walking", "Sitting", "In a vehicle"],
       datasets: [
           {
           label: "Breakdown by activity name in the past week",

--- a/src/variables/charts_data.js
+++ b/src/variables/charts_data.js
@@ -113,11 +113,11 @@ let chartExample1 = {
             var label = data.datasets[item.datasetIndex].label || "";
             var yLabel = item.yLabel;
             var content = "";
-  
+
             if (data.datasets.length > 1) {
               content += label;
             }
-  
+
             // content += '$' + yLabel + 'k';
             content += yLabel;
             return content;
@@ -159,7 +159,7 @@ let chartExample1 = {
       };
     }
 };
-  
+
   // Example 2 of Chart inside src/views/Index.js (Total orders - Card)
 let chartExample2 = {
 options: {
@@ -222,7 +222,7 @@ data1: canvas => {//Sleep by week
     };
 },
 data2: canvas => { //sleep by month
-    return {  
+    return {
     labels: ["Week 1", "Week 2", "Week 3", "Week 4"],
     datasets: [
         {
@@ -268,13 +268,13 @@ let chartExample3 = {
 
     data1: canvas => {
         return {
-        labels: ["Very High (20-25)", "High (15-20)", "Moderate (10-15)", "Low (0-15)"],
+        labels: ["Calling", "Messaging", "Social Media", "No social interaction"],
         datasets: [
             {
             label: "Stress count by score in the past month",
             data: global_data["stress_pie_score"]["week"],//[1, 5, 4, 7],
             backgroundColor: [
-                "#A91E2A",
+                "#228B22",
                 '#ff4242',
                 '#002867',
                 '#DCDCDC'
@@ -424,7 +424,7 @@ let chartExample5 = {
     };
   }
 };
-  
+
   // Example 2 of Chart inside src/views/Index.js (Total orders - Card)
 let chartExample6 = {
 options: {
@@ -473,7 +473,7 @@ data1: canvas => {
     };
 },
 data2: canvas => {
-    return {  
+    return {
     labels: ["Week 1", "Week 2", "Week 3", "Week 4"],
     datasets: [
         {
@@ -725,7 +725,7 @@ let step_counts = {
       };
   },
   data2: canvas => {
-      return {  
+      return {
       labels: ["Week 1", "Week 2", "Week 3", "Week 4"],
       datasets: [
           {
@@ -736,13 +736,13 @@ let step_counts = {
       };
   }
 }
-  
+
 /* dummy class to do basically the same thing that the previous code was doing
    but inside a class. This is to prevent premature running of the getChartData
    function when this file is loaded by the browser.
-   
+
    Problem: since the function was not in a component, it ran as soon as the file
-   loaded (when the website is loaded) and this makes it run when the credentials 
+   loaded (when the website is loaded) and this makes it run when the credentials
    needed to pull data from firstore are not yet available.
 
    Solution: put the code in a dummy class so that it is only loaded when the parent
@@ -752,12 +752,12 @@ let step_counts = {
 class ChartsData extends React.Component {
   getChartData = async () => {
     const uid = localStorage.getItem("uid")
-  
+
     var docRef = db.collection("users").doc(uid).collection("charts")
     var doc = await docRef.get()
-  
+
     doc.docs.map(doc => global_data[doc.id] = doc.data())
-  
+
     global_data["stress_bar_score"] = global_data["stress_pie_score"]
     global_data["stress_bar_type"] = global_data["stress_pie_type"]
 
@@ -789,13 +789,13 @@ export default connect(
 )(ChartsData);
 
 export {
-  chartExample1, 
-  chartExample2, 
-  chartExample3, 
-  chartExample4, 
-  chartExample5, 
-  chartExample6, 
-  chartExample7, 
+  chartExample1,
+  chartExample2,
+  chartExample3,
+  chartExample4,
+  chartExample5,
+  chartExample6,
+  chartExample7,
   chartExample8,
   step_counts,
   activity_pie

--- a/src/views/Index.js
+++ b/src/views/Index.js
@@ -74,7 +74,7 @@ class Index extends React.Component {
     let sort = !this.state.stressSort;
     this.setState({
       stressSort: !this.state.stressSort,
-      stressIncidents: sort ? 
+      stressIncidents: sort ?
         this.state.stressIncidents.sort((a,b) => b.stress_score - a.stress_score) : this.state.stressIncidents.sort((a,b) => a.stress_score - b.stress_score),
     });
   }
@@ -86,7 +86,7 @@ class Index extends React.Component {
         {/* Page content */}
         <Container className="mt--7" fluid>
           <Graphs />
-          <Row className="mt-5">
+          {/* <Row className="mt-5">
             <Col className="mb-5 mb-xl-0" xl="12">
               <Card className="shadow">
                 <CardHeader className="border-0">
@@ -107,11 +107,11 @@ class Index extends React.Component {
                     </tr>
                   </thead>
                   <tbody>
-                    {this.state.stressIncidents.map(incident => 
+                    {this.state.stressIncidents.map(incident =>
                       <tr>
                         <td key={String(incident.index)+String(incident.index)}>
-                          <Input 
-                            type="select" 
+                          <Input
+                            type="select"
                             defaultValue={incident.reason}
                             onChange={(e) => console.log(`stress reason changed to ${e.target.value}`)}
                           >
@@ -132,16 +132,16 @@ class Index extends React.Component {
                             plaintext={!this.state.showTextBox[incident.index]}
                             onDoubleClick={(e) => {
                               e.preventDefault();
-                              this.state.showTextBox[incident.index] = true; 
+                              this.state.showTextBox[incident.index] = true;
                               // this.forceUpdate();
                               this.setState();
                             }}
                           />
                           <UncontrolledTooltip delay={0} placement='right' trigger="hover focus" target={'Box'+incident.index}>
                             Double Click Me to Edit!
-                          </UncontrolledTooltip>                          
+                          </UncontrolledTooltip>
                           {
-                            this.state.showTextBox[incident.index] && 
+                            this.state.showTextBox[incident.index] &&
                             <Button
                               color='default'
                               size="sm"
@@ -166,7 +166,7 @@ class Index extends React.Component {
                 </Table>
               </Card>
             </Col>
-          </Row>
+          </Row> */}
         </Container>
       </>
     );

--- a/src/views/examples/Charts_page.js
+++ b/src/views/examples/Charts_page.js
@@ -239,7 +239,7 @@ class Charts extends React.Component {
                     <h6 className="text-uppercase text-muted ls-1 mb-1">
                         Overview
                     </h6>
-                    <h2 className="mb-0">Stress Breakdown (by score)</h2>
+                    <h2 className="mb-0">Stress Breakdown (by score ORANGES)</h2>
                     </div>
                     <div className="col">
                     <Nav className="justify-content-end" pills>
@@ -340,7 +340,7 @@ class Charts extends React.Component {
                 </Card>
             </Col>
             </Row>
-            
+
         </Container>
         <Container className="mt-5" fluid>
             <Graphs/>

--- a/src/views/graphs.js
+++ b/src/views/graphs.js
@@ -169,71 +169,7 @@ class Graphs extends Component {
             </div>
           }
           <Row>
-              <Col className="mb-5 mb-xl-0" xl="8">
-              <Card className="bg-gradient-default shadow">
-                  <CardHeader className="bg-transparent">
-                  <Row className="align-items-center">
-                      <div className="col">
-                      <h6 className="text-uppercase text-light ls-1 mb-1">
-                          Overview
-                      </h6>
-                      <h2 className="text-white mb-0">Stress Score</h2>
-                      </div>
-                      <div className="col">
-                      <Nav className="justify-content-end" pills>
-                          <NavItem>
-                          <NavLink
-                              className={classnames("py-2 px-3", {
-                              active: this.state.activeNav1 === 1
-                              })}
-                              href="#pablo"
-                              onClick={e => this.toggleNavs(e, 1, 1, 1)}
-                          >
-                              <span className="d-none d-md-block">Day</span>
-                              <span className="d-md-none">D</span>
-                          </NavLink>
-                          </NavItem>
-                          <NavItem>
-                          <NavLink
-                              className={classnames("py-2 px-3", {
-                              active: this.state.activeNav1 === 2
-                              })}
-                              data-toggle="tab"
-                              href="#pablo"
-                              onClick={e => this.toggleNavs(e, 1, 1, 2)}
-                          >
-                              <span className="d-none d-md-block">Week</span>
-                              <span className="d-md-none">W</span>
-                          </NavLink>
-                          </NavItem>
-                          <NavItem>
-                          <NavLink
-                              className={classnames("py-2 px-3", {
-                              active: this.state.activeNav1 === 3
-                              })}
-                              href="#pablo"
-                              onClick={e => this.toggleNavs(e, 1, 1, 3)}
-                          >
-                              <span className="d-none d-md-block">Month</span>
-                              <span className="d-md-none">M</span>
-                          </NavLink>
-                          </NavItem>
-                      </Nav>
-                      </div>
-                  </Row>
-                  </CardHeader>
-                  <CardBody>
-                  {/* Chart */}
-                  <div className="chart">
-                      <Line
-                      data={chartExample1[this.state.chartExample1Data]}
-                      options={chartExample1.options}
-                      getDatasetAtEvent={e => console.log(e)}
-                      />
-                  </div>
-                  </CardBody>
-              </Card>
-              </Col>
+
               <Col xl="4">
               <Card className="shadow">
                   <CardHeader className="bg-transparent">
@@ -242,7 +178,7 @@ class Graphs extends Component {
                       <h6 className="text-uppercase text-muted ls-1 mb-1">
                           Overview
                       </h6>
-                      <h2 className="mb-0">Sleep</h2>
+                      <h2 className="mb-0">Sleep (hours)</h2>
                       </div>
                       <div>
                       <Nav className="justify-content-end" pills>
@@ -408,7 +344,7 @@ class Graphs extends Component {
                     <h6 className="text-uppercase text-muted ls-1 mb-1">
                       Overview
                     </h6>
-                    <h2 className="mb-0">Stress Breakdown (by score)</h2>
+                    <h2 className="mb-0">Social Activities</h2>
                     </div>
                     <div className="col">
                     <Nav className="justify-content-end" pills>
@@ -454,60 +390,7 @@ class Graphs extends Component {
                 </CardBody>
               </Card>
             </Col>
-            <Col className="mb-5 mb-xl-0" xl="6">
-              <Card className="shadow">
-              <CardHeader className="bg-transparent">
-                  <Row className="align-items-center">
-                    <div className="col">
-                    <h6 className="text-uppercase text-muted ls-1 mb-1">
-                      Overview
-                    </h6>
-                    <h2 className="mb-0">Stress Breakdown (by type)</h2>
-                    </div>
-                    <div className="col">
-                    <Nav className="justify-content-end" pills>
-                        <NavItem>
-                        <NavLink
-                            className={classnames("py-2 px-3", {
-                            active: this.state.activeNav4 === 1
-                            })}
-                            href="#pablo"
-                            onClick={e => this.toggleNavs(e, 3, 2, 1)}
-                            // onClick={e => e.preventDefault()}
-                            >
-                            <span className="d-none d-md-block">Week</span>
-                            <span className="d-md-none">W</span>
-                        </NavLink>
-                        </NavItem>
-                        <NavItem>
-                        <NavLink
-                            className={classnames("py-2 px-3", {
-                            active: this.state.activeNav4 === 2
-                            })}
-                            href="#pablo"
-                            onClick={e => this.toggleNavs(e, 3, 2, 2)}
-                            // onClick={e => e.preventDefault()}
-                            >
-                            <span className="d-none d-md-block">Month</span>
-                            <span className="d-md-none">M</span>
-                        </NavLink>
-                        </NavItem>
-                    </Nav>
-                    </div>
-                  </Row>
-              </CardHeader>
-              <CardBody>
-                {/* Chart */}
-                <div className="chart">
-                    <Pie
-                    data={chartExample4[this.state.chartExample4Data]}
-                    options={chartExample4.options}
-                    getDatasetAtEvent={e => console.log(e)}
-                    />
-                </div>
-                </CardBody>
-              </Card>
-            </Col>
+
           </Row>
         </>
       );

--- a/src/views/graphs.js
+++ b/src/views/graphs.js
@@ -233,7 +233,7 @@ class Graphs extends Component {
                     <h6 className="text-uppercase text-muted ls-1 mb-1">
                       Overview
                     </h6>
-                    <h2 className="mb-0">Activity Breakdown</h2>
+                    <h2 className="mb-0">Activity Breakdown (minutes)</h2>
                     </div>
                     <div className="col">
                     <Nav className="justify-content-end" pills>
@@ -344,7 +344,7 @@ class Graphs extends Component {
                     <h6 className="text-uppercase text-muted ls-1 mb-1">
                       Overview
                     </h6>
-                    <h2 className="mb-0">Social Activities</h2>
+                    <h2 className="mb-0">Social Activities (minutes)</h2>
                     </div>
                     <div className="col">
                     <Nav className="justify-content-end" pills>

--- a/src/views/graphs.js
+++ b/src/views/graphs.js
@@ -351,6 +351,20 @@ class Graphs extends Component {
                         <NavItem>
                         <NavLink
                             className={classnames("py-2 px-3", {
+                            // TODO(tdavis): Make this actually toggle properly
+                            active: this.state.activeNav3 === 2
+                            })}
+                            href="#pablo"
+                            onClick={e => this.toggleNavs(e, 3, 1, 1)}
+                            // onClick={e => e.preventDefault()}
+                            >
+                            <span className="d-none d-md-block">Day</span>
+                            <span className="d-md-none">D</span>
+                        </NavLink>
+                        </NavItem>
+                        <NavItem>
+                        <NavLink
+                            className={classnames("py-2 px-3", {
                             active: this.state.activeNav3 === 1
                             })}
                             href="#pablo"
@@ -359,19 +373,6 @@ class Graphs extends Component {
                             >
                             <span className="d-none d-md-block">Week</span>
                             <span className="d-md-none">W</span>
-                        </NavLink>
-                        </NavItem>
-                        <NavItem>
-                        <NavLink
-                            className={classnames("py-2 px-3", {
-                            active: this.state.activeNav3 === 2
-                            })}
-                            href="#pablo"
-                            onClick={e => this.toggleNavs(e, 3, 1, 2)}
-                            // onClick={e => e.preventDefault()}
-                            >
-                            <span className="d-none d-md-block">Month</span>
-                            <span className="d-md-none">M</span>
                         </NavLink>
                         </NavItem>
                     </Nav>


### PR DESCRIPTION
Items to address:

* On the Sleep graph, it might be helpful to have a key for green, yellow, red. Similar to the Activity Breakdown graph key. 
* For Activity, the overview number is in miles, but the graph is in steps. Seems like we should choose one or the other to be consistent.
* I don’t think “since last week” is exactly right. Could be “daily during the last 7 days” (if it’s a 7-day rolling count), or something like that. Unless it’s really Sunday-Saturday.
* On the detail graphs, let’s go with D W (day week). I think M (month) is too long to be useful when looking at change.
* On the detail graphs, the label is “Overview”. Is there something more detailed they get from clicking? If not, perhaps a different title.
* On Activity, perhaps it should be “Driving or Riding”, in case they are on a bus? Are there other options from the google activity API? I seem to recall riding a bike or something, too.
* On Social Activities detail graph, what is the Unit, minutes? Good perhaps to state something.