### PR TITLE
Miscellaneous changes for the dashboard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11313,6 +11313,11 @@
         "lodash._reinterpolate": "^3.0.0"
       }
     },
+    "lodash.throttle": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
+      "integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ="
+    },
     "lodash.uniq": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
@@ -16285,6 +16290,15 @@
             "lodash": "^4.17.15"
           }
         }
+      }
+    },
+    "react-scroll": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/react-scroll/-/react-scroll-1.8.2.tgz",
+      "integrity": "sha512-f2ZEG5fsPbPTySI9ekcFpETCcNlqbmwbQj9hhzYK8tkgv+PA8APatSt66o/q0KSkDZxyT98ONTtXp9x0lyowEw==",
+      "requires": {
+        "lodash.throttle": "^4.1.1",
+        "prop-types": "^15.7.2"
       }
     },
     "react-transition-group": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "react-relay": "^9.0.0",
     "react-router-dom": "^5.1.2",
     "react-scripts": "3.4.1",
+    "react-scroll": "^1.8.2",
     "reactstrap": "8.4.1",
     "redux": "^4.0.5"
   },

--- a/src/components/Headers/Header.js
+++ b/src/components/Headers/Header.js
@@ -3,6 +3,10 @@ import React from "react";
 // reactstrap components
 import { Card, CardBody, CardTitle, Container, Row, Col } from "reactstrap";
 
+import {
+  Link
+} from 'react-scroll'
+
 import {connect} from 'react-redux'
 
 class Header extends React.Component {
@@ -15,112 +19,118 @@ class Header extends React.Component {
               {/* Card stats */}
               <Row>
                 <Col lg="6" xl="3">
-                  <Card className="card-stats mb-4 mb-xl-0">
-                    <CardBody>
-                      <Row>
-                        <div className="col">
-                          <CardTitle
-                            tag="h5"
-                            className="text-uppercase text-muted mb-0"
-                          >
-                            Steps Taken
-                          </CardTitle>
-                          <span className="h2 font-weight-bold mb-0">
-                            {this.props.overalls["step_counts"] && this.props.overalls["step_counts"]["score"]}
-                          </span>
-                        </div>
-                        <Col className="col-auto">
-                          <div className="icon icon-shape bg-danger text-white rounded-circle shadow">
-                            <i className="fas fa-chart-bar" />
+                  <Link to="steps_graph" offset={-10} duration={750} smooth={true}>
+                    <Card className="card-stats mb-4 mb-xl-0">
+                      <CardBody>
+                        <Row>
+                          <div className="col">
+                            <CardTitle
+                              tag="h5"
+                              className="text-uppercase text-muted mb-0"
+                            >
+                              Steps Taken
+                            </CardTitle>
+                            <span className="h2 font-weight-bold mb-0">
+                              {this.props.overalls["step_counts"] && this.props.overalls["step_counts"]["score"]}
+                            </span>
                           </div>
-                        </Col>
-                      </Row>
-                      <p className="mt-3 mb-0 text-muted text-sm">
-                        {this.props.overalls["step_counts"] && this.props.overalls["step_counts"]["value_change"] === "up" ?
-                          (<span className="text-danger mr-2">
-                            <i className="fa fa-arrow-up" /> {this.props.overalls["step_counts"]["percent_change"]}%
-                          </span>)
-                          :
-                          (<span className="text-danger mr-2">
-                            <i className="fa fa-arrow-down" /> {this.props.overalls["step_counts"] && this.props.overalls["step_counts"]["percent_change"]}%
-                          </span>)
-                          }{" "}
-                        <span className="text-nowrap">Last seven days</span>
-                      </p>
-                    </CardBody>
-                  </Card>
+                          <Col className="col-auto">
+                            <div className="icon icon-shape bg-danger text-white rounded-circle shadow">
+                              <i className="fas fa-chart-bar" />
+                            </div>
+                          </Col>
+                        </Row>
+                        <p className="mt-3 mb-0 text-muted text-sm">
+                          {this.props.overalls["step_counts"] && this.props.overalls["step_counts"]["value_change"] === "up" ?
+                            (<span className="text-danger mr-2">
+                              <i className="fa fa-arrow-up" /> {this.props.overalls["step_counts"]["percent_change"]}%
+                            </span>)
+                            :
+                            (<span className="text-danger mr-2">
+                              <i className="fa fa-arrow-down" /> {this.props.overalls["step_counts"] && this.props.overalls["step_counts"]["percent_change"]}%
+                            </span>)
+                            }{" "}
+                          <span className="text-nowrap">Last seven days</span>
+                        </p>
+                      </CardBody>
+                      </Card>
+                    </Link>
                 </Col>
                 <Col lg="6" xl="3">
-                  <Card className="card-stats mb-4 mb-xl-0">
-                    <CardBody>
-                      <Row>
-                        <div className="col">
-                          <CardTitle
-                            tag="h5"
-                            className="text-uppercase text-muted mb-0"
-                          >
-                            Sleep
-                          </CardTitle>
-                          <span className="h2 font-weight-bold mb-0">
-                            {this.props.overalls["sleep"] && this.props.overalls["sleep"]["score"] } hours/night
-                          </span>
-                        </div>
-                        <Col className="col-auto">
-                          <div className="icon icon-shape bg-warning text-white rounded-circle shadow">
-                            <i className="fas fa-chart-pie" />
+                  <Link to="sleep_graph" offset={-10} duration={750} smooth={true}>
+                    <Card className="card-stats mb-4 mb-xl-0">
+                      <CardBody>
+                        <Row>
+                          <div className="col">
+                            <CardTitle
+                              tag="h5"
+                              className="text-uppercase text-muted mb-0"
+                            >
+                              Sleep
+                            </CardTitle>
+                            <span className="h2 font-weight-bold mb-0">
+                              {this.props.overalls["sleep"] && this.props.overalls["sleep"]["score"] } hours/night
+                            </span>
                           </div>
-                        </Col>
-                      </Row>
-                      <p className="mt-3 mb-0 text-muted text-sm">
-                        {this.props.overalls["sleep"] && this.props.overalls["sleep"]["value_change"] === "up" ?
-                          (<span className="text-success mr-2">
-                            <i className="fa fa-arrow-up" /> {this.props.overalls["sleep"]["percent_change"]}%
-                          </span>)
-                          :
-                          (<span className="text-danger mr-2">
-                            <i className="fa fa-arrow-down" /> {this.props.overalls["sleep"] && this.props.overalls["sleep"]["percent_change"]}%
-                          </span>)
-                          }{" "}
-                        <span className="text-nowrap">Last seven days</span>
-                      </p>
-                    </CardBody>
-                  </Card>
+                          <Col className="col-auto">
+                            <div className="icon icon-shape bg-warning text-white rounded-circle shadow">
+                              <i className="fas fa-chart-pie" />
+                            </div>
+                          </Col>
+                        </Row>
+                        <p className="mt-3 mb-0 text-muted text-sm">
+                          {this.props.overalls["sleep"] && this.props.overalls["sleep"]["value_change"] === "up" ?
+                            (<span className="text-success mr-2">
+                              <i className="fa fa-arrow-up" /> {this.props.overalls["sleep"]["percent_change"]}%
+                            </span>)
+                            :
+                            (<span className="text-danger mr-2">
+                              <i className="fa fa-arrow-down" /> {this.props.overalls["sleep"] && this.props.overalls["sleep"]["percent_change"]}%
+                            </span>)
+                            }{" "}
+                          <span className="text-nowrap">Last seven days</span>
+                        </p>
+                      </CardBody>
+                    </Card>
+                  </Link>
                 </Col>
                 <Col lg="6" xl="3">
-                  <Card className="card-stats mb-4 mb-xl-0">
-                    <CardBody>
-                      <Row>
-                        <div className="col">
-                          <CardTitle
-                            tag="h5"
-                            className="text-uppercase text-muted mb-0"
-                          >
-                            Social Activity
-                          </CardTitle>
-                          <span className="h2 font-weight-bold mb-0">
-                            {this.props.overalls["stress_management"] && this.props.overalls["stress_management"]["score"]} mins/day
-                          </span>
-                        </div>
-                        <Col className="col-auto">
-                          <div className="icon icon-shape bg-yellow text-white rounded-circle shadow">
-                            <i className="fas fa-users" />
+                  <Link to="social_graph" offset={-10} duration={750} smooth={true}>
+                    <Card className="card-stats mb-4 mb-xl-0">
+                      <CardBody>
+                        <Row>
+                          <div className="col">
+                            <CardTitle
+                              tag="h5"
+                              className="text-uppercase text-muted mb-0"
+                            >
+                              Social Activity
+                            </CardTitle>
+                            <span className="h2 font-weight-bold mb-0">
+                              {this.props.overalls["stress_management"] && this.props.overalls["stress_management"]["score"]} mins/day
+                            </span>
                           </div>
-                        </Col>
-                      </Row>
-                      <p className="mt-3 mb-0 text-muted text-sm">
-                        {this.props.overalls["stress_management"] && this.props.overalls["stress_management"]["value_change"] === "up" ?
-                          (<span className="text-success mr-2">
-                            <i className="fa fa-arrow-up" /> {this.props.overalls["stress_management"]["percent_change"]}%
-                          </span>)
-                          :
-                          (<span className="text-danger mr-2">
-                            <i className="fa fa-arrow-down" /> {this.props.overalls["stress_management"] && this.props.overalls["stress_management"]["percent_change"]}%
-                          </span>)
-                          }{" "}
-                        <span className="text-nowrap">Last seven days</span>
-                      </p>
-                    </CardBody>
-                  </Card>
+                          <Col className="col-auto">
+                            <div className="icon icon-shape bg-yellow text-white rounded-circle shadow">
+                              <i className="fas fa-users" />
+                            </div>
+                          </Col>
+                        </Row>
+                        <p className="mt-3 mb-0 text-muted text-sm">
+                          {this.props.overalls["stress_management"] && this.props.overalls["stress_management"]["value_change"] === "up" ?
+                            (<span className="text-success mr-2">
+                              <i className="fa fa-arrow-up" /> {this.props.overalls["stress_management"]["percent_change"]}%
+                            </span>)
+                            :
+                            (<span className="text-danger mr-2">
+                              <i className="fa fa-arrow-down" /> {this.props.overalls["stress_management"] && this.props.overalls["stress_management"]["percent_change"]}%
+                            </span>)
+                            }{" "}
+                          <span className="text-nowrap">Last seven days</span>
+                        </p>
+                      </CardBody>
+                    </Card>
+                  </Link>
                 </Col>
                 {/* <Col lg="6" xl="3">
                   <Card className="card-stats mb-4 mb-xl-0">

--- a/src/components/Navbars/AdminNavbar.js
+++ b/src/components/Navbars/AdminNavbar.js
@@ -73,10 +73,6 @@ class AdminNavbar extends React.Component {
                     <i className="ni ni-single-02" />
                     <span>My profile</span>
                   </DropdownItem>
-                  <DropdownItem to="/admin/user-profile" tag={Link}>
-                    <i className="ni ni-settings-gear-65" />
-                    <span>Settings</span>
-                  </DropdownItem>
                   <DropdownItem divider />
                   <DropdownItem to="/auth/login" tag={Link} onClick={(e) => this.tryLogOut()}>
                     <i className="ni ni-user-run" />

--- a/src/components/Sidebar/Sidebar.js
+++ b/src/components/Sidebar/Sidebar.js
@@ -143,10 +143,6 @@ class Sidebar extends React.Component {
                   <i className="ni ni-single-02" />
                   <span>My profile</span>
                 </DropdownItem>
-                <DropdownItem to="/admin/user-profile" tag={Link}>
-                  <i className="ni ni-settings-gear-65" />
-                  <span>Settings</span>
-                </DropdownItem>
                 <DropdownItem divider />
                 <DropdownItem to="/auth/login" tag={Link} onClick={e => {e.preventDefault(); window.location.href = "/auth/login"}}>
                   <i className="ni ni-user-run" />

--- a/src/routes.js
+++ b/src/routes.js
@@ -19,7 +19,7 @@ import Index from "views/Index.js";
 import Profile from "views/examples/Profile.js";
 import Register from "views/examples/Register.js";
 import Login from "views/examples/Login.js";
-import Charts from "views/examples/Charts_page.js";
+// import Charts from "views/examples/Charts_page.js";
 // import Journal from "views/examples/Journal/Journal.js";
 
 var routes = [
@@ -37,13 +37,13 @@ var routes = [
     component: Profile,
     layout: "/admin"
   },
-  {
-    path: "/charts",
-    name: "Charts",
-    icon: "ni ni-bullet-list-67 text-red",
-    component: Charts,
-    layout: "/admin"
-  },
+  // {
+  //   path: "/charts",
+  //   name: "Charts",
+  //   icon: "ni ni-bullet-list-67 text-red",
+  //   component: Charts,
+  //   layout: "/admin"
+  // },
   {
     path: "/login",
     name: "Login",

--- a/src/variables/charts_data.js
+++ b/src/variables/charts_data.js
@@ -49,7 +49,8 @@ let global_data = {
   },
   "activity_pie": {
     "day": [],
-    "week": []
+    "week": [],
+    "month": []
   },
   "sleep": {
     "week": {
@@ -66,6 +67,7 @@ let global_data = {
     }
   },
   "stress_pie_score": {
+    "day": [],
     "week": [],
     "month": [],
   },
@@ -279,8 +281,8 @@ let chartExample3 = {
         labels: ["Calling", "Messaging", "Social Media", "No social interaction"],
         datasets: [
             {
-            label: "Stress count by score in the past month",
-            data: global_data["stress_pie_score"]["week"],//[1, 5, 4, 7],
+            label: "Social activity in the past day",
+            data: global_data["stress_pie_score"]["day"],//[1, 5, 4, 7],
             backgroundColor: [
                 "#228B22",
                 '#ff4242',
@@ -297,7 +299,26 @@ let chartExample3 = {
         labels: ["Calling", "Messaging", "Social Media", "No social interaction"],
         datasets: [
             {
-            label: "Stress count by score in the past month",
+            label: "Social activity in the past week",
+            data: global_data["stress_pie_score"]["week"],//[3, 25, 61, 15],
+            backgroundColor: [
+                "#228B22",
+                '#ff4242',
+                '#002867',
+                '#DCDCDC'
+                ],
+            }
+        ],
+        innerWidth: 100,
+        }
+    },
+    
+    data3: canvas => {
+        return {
+        labels: ["Calling", "Messaging", "Social Media", "No social interaction"],
+        datasets: [
+            {
+            label: "Social activity in the past month",
             data: global_data["stress_pie_score"]["month"],//[3, 25, 61, 15],
             backgroundColor: [
                 "#228B22",
@@ -675,6 +696,26 @@ let activity_pie = {
           {
           label: "Breakdown by activity name in the past week",
           data: global_data["activity_pie"]["week"],
+          backgroundColor: [
+            "#A91E2A",
+            '#ff4242',
+            '#002867',
+            '#DCDCDC',
+            "#228B22",
+            ],
+          }
+      ],
+      innerWidth: 100,
+      }
+  },
+
+  data3: canvas => {
+      return {
+      labels: ["Running", "Walking", "Sitting", "In a vehicle", "Biking"],
+      datasets: [
+          {
+          label: "Breakdown by activity name in the past month",
+          data: global_data["activity_pie"]["month"],
           backgroundColor: [
             "#A91E2A",
             '#ff4242',

--- a/src/views/examples/Charts_page.js
+++ b/src/views/examples/Charts_page.js
@@ -123,58 +123,6 @@ class Charts extends React.Component {
         <div className="header bg-gradient-info pb-8 pt-5 pt-md-8"/>
         <Container className="mt--7" fluid>
             <Row>
-                <Col className="mb-5 mb-xl-0" xl="5">
-                <Card className="shadow">
-                    <CardHeader className="bg-transparent">
-                    <Row className="align-items-center">
-                        <div className="col">
-                        <h6 className="text-uppercase text-muted ls-1 mb-1">
-                            Overview
-                        </h6>
-                        <h2 className="mb-0">Stress Management</h2>
-                        </div>
-                        <div>
-                        <Nav className="justify-content-end" pills>
-                            <NavItem>
-                            <NavLink
-                                className={classnames("py-2 px-3", {
-                                active: this.state.activeNav2 === 1
-                                })}
-                                href="#pablo"
-                                onClick={e => this.toggleNavs(e, 1, 2, 1)}
-                                >
-                                <span className="d-none d-md-block">Week</span>
-                                <span className="d-md-none">W</span>
-                            </NavLink>
-                            </NavItem>
-                            <NavItem>
-                            <NavLink
-                                className={classnames("py-2 px-3", {
-                                active: this.state.activeNav2 === 2
-                                })}
-                                href="#pablo"
-                                onClick={e => this.toggleNavs(e, 1, 2, 2)}
-                                >
-                                <span className="d-none d-md-block">Month</span>
-                                <span className="d-md-none">M</span>
-                            </NavLink>
-                            </NavItem>
-                        </Nav>
-                        </div>
-                    </Row>
-                    </CardHeader>
-                    <CardBody>
-                    {/* Chart */}
-                    <div className="chart">
-                        <Bar
-                        data={chartExample2[this.state.chartExample2Data]}
-                        options={chartExample2.options}
-                        getDatasetAtEvent={e => console.log(e)}
-                        />
-                    </div>
-                    </CardBody>
-                </Card>
-                </Col>
                 <Col className="mb-5 mb-xl-0" xl="7">
                 <Card className="bg-gradient-default shadow">
                     <CardHeader className="bg-transparent">

--- a/src/views/examples/Profile.js
+++ b/src/views/examples/Profile.js
@@ -106,14 +106,6 @@ class Profile extends React.Component {
                       <i className="ni location_pin mr-2" />
                       Los Angeles, United States
                     </div>
-                    <div className="h5 mt-4">
-                      <i className="ni business_briefcase-24 mr-2" />
-                      Your Work Title
-                    </div>
-                    <div>
-                      <i className="ni education_hat mr-2" />
-                      Place of Work
-                    </div>
                     {/* <hr className="my-4" />
                     <p>
                       Ryan — the name taken by Melbourne-raised, Brooklyn-based
@@ -216,81 +208,6 @@ class Profile extends React.Component {
                               id="input-last-name"
                               placeholder="Last name"
                               type="text"
-                            />
-                          </FormGroup>
-                        </Col>
-                      </Row>
-                    </div>
-                    <hr className="my-4" />
-                    {/* Address */}
-                    <h6 className="heading-small text-muted mb-4">
-                      Contact information
-                    </h6>
-                    <div className="pl-lg-4">
-                      <Row>
-                        <Col md="12">
-                          <FormGroup>
-                            <label
-                              className="form-control-label"
-                              htmlFor="input-address"
-                            >
-                              Address
-                            </label>
-                            <Input
-                              className="form-control-alternative"
-                              id="input-address"
-                              placeholder="Home Address"
-                              type="text"
-                            />
-                          </FormGroup>
-                        </Col>
-                      </Row>
-                      <Row>
-                        <Col lg="4">
-                          <FormGroup>
-                            <label
-                              className="form-control-label"
-                              htmlFor="input-city"
-                            >
-                              City
-                            </label>
-                            <Input
-                              className="form-control-alternative"
-                              id="input-city"
-                              placeholder="City"
-                              type="text"
-                            />
-                          </FormGroup>
-                        </Col>
-                        <Col lg="4">
-                          <FormGroup>
-                            <label
-                              className="form-control-label"
-                              htmlFor="input-country"
-                            >
-                              Country
-                            </label>
-                            <Input
-                              className="form-control-alternative"
-                              id="input-country"
-                              placeholder="Country"
-                              type="text"
-                            />
-                          </FormGroup>
-                        </Col>
-                        <Col lg="4">
-                          <FormGroup>
-                            <label
-                              className="form-control-label"
-                              htmlFor="input-country"
-                            >
-                              Postal code
-                            </label>
-                            <Input
-                              className="form-control-alternative"
-                              id="input-postal-code"
-                              placeholder="Postal code"
-                              type="number"
                             />
                           </FormGroup>
                         </Col>

--- a/src/views/graphs.js
+++ b/src/views/graphs.js
@@ -104,9 +104,14 @@ class Graphs extends Component {
               chartExample5Data: "data1"
             });
           }
-          else {
+          else if (data === 2){
             this.setState({
               chartExample5Data: "data2"
+            });
+          }
+          else {
+            this.setState({
+              chartExample5Data: "data3"
             });
           }
         }
@@ -136,9 +141,14 @@ class Graphs extends Component {
               chartExample3Data: "data1"
             });
           }
-          else {
+          else if (data === 2){
             this.setState({
               chartExample3Data: "data2"
+            });
+          }
+          else {
+            this.setState({
+              chartExample3Data: "data3"
             });
           }
         }
@@ -263,6 +273,19 @@ class Graphs extends Component {
                             <span className="d-md-none">W</span>
                         </NavLink>
                         </NavItem>
+                        <NavItem>
+                        <NavLink
+                            className={classnames("py-2 px-3", {
+                            active: this.state.activeNav5 === 3
+                            })}
+                            href="#pablo"
+                            onClick={e => this.toggleNavs(e, 2, 1, 3)}
+                            // onClick={e => e.preventDefault()}
+                            >
+                            <span className="d-none d-md-block">Month</span>
+                            <span className="d-md-none">M</span>
+                        </NavLink>
+                        </NavItem>
                     </Nav>
                     </div>
                   </Row>
@@ -372,6 +395,19 @@ class Graphs extends Component {
                             >
                             <span className="d-none d-md-block">Week</span>
                             <span className="d-md-none">W</span>
+                        </NavLink>
+                        </NavItem>
+                        <NavItem>
+                        <NavLink
+                            className={classnames("py-2 px-3", {
+                            active: this.state.activeNav3 === 3
+                            })}
+                            href="#pablo"
+                            onClick={e => this.toggleNavs(e, 3, 1, 3)}
+                            // onClick={e => e.preventDefault()}
+                            >
+                            <span className="d-none d-md-block">Month</span>
+                            <span className="d-md-none">M</span>
                         </NavLink>
                         </NavItem>
                     </Nav>

--- a/src/views/graphs.js
+++ b/src/views/graphs.js
@@ -18,6 +18,10 @@ import {
   } from "reactstrap";
 
 import {
+  Element,
+} from 'react-scroll'
+
+import {
     chartOptions,
     parseOptions,
 } from "variables/charts.js";
@@ -179,9 +183,9 @@ class Graphs extends Component {
             </div>
           }
           <Row>
-
-              <Col xl="4">
-              <Card className="shadow">
+            <Col xl="4">
+              <Element name="sleep_graph">
+                <Card className="shadow">
                   <CardHeader className="bg-transparent">
                   <Row className="align-items-center">
                       <div className="col">
@@ -230,8 +234,9 @@ class Graphs extends Component {
                       />
                   </div>
                   </CardBody>
-              </Card>
-              </Col>
+                </Card>
+              </Element>
+            </Col>
           </Row>
           {/*Second Row */}
           <Row className="mt-5">
@@ -303,128 +308,132 @@ class Graphs extends Component {
               </Card>
             </Col>
             <Col className="mb-5 mb-xl-0" xl="6">
-              <Card className="shadow">
-              <CardHeader className="bg-transparent">
-                  <Row className="align-items-center">
-                    <div className="col">
-                    <h6 className="text-uppercase text-muted ls-1 mb-1">
-                      Overview
-                    </h6>
-                    <h2 className="mb-0">Step Counts</h2>
-                    </div>
-                    <div className="col">
-                    <Nav className="justify-content-end" pills>
-                        <NavItem>
-                        <NavLink
-                            className={classnames("py-2 px-3", {
-                            active: this.state.activeNav6 === 1
-                            })}
-                            href="#pablo"
-                            onClick={e => this.toggleNavs(e, 2, 2, 1)}
-                            // onClick={e => e.preventDefault()}
-                            >
-                            <span className="d-none d-md-block">Week</span>
-                            <span className="d-md-none">W</span>
-                        </NavLink>
-                        </NavItem>
-                        <NavItem>
-                        <NavLink
-                            className={classnames("py-2 px-3", {
-                            active: this.state.activeNav6 === 2
-                            })}
-                            href="#pablo"
-                            onClick={e => this.toggleNavs(e, 2, 2, 2)}
-                            // onClick={e => e.preventDefault()}
-                            >
-                            <span className="d-none d-md-block">Month</span>
-                            <span className="d-md-none">M</span>
-                        </NavLink>
-                        </NavItem>
-                    </Nav>
-                    </div>
-                  </Row>
-              </CardHeader>
-              <CardBody>
-                {/* Chart */}
-                <div className="chart">
-                    <Bar
-                    data={chartExample6[this.state.chartExample6Data]}
-                    options={chartExample6.options}
-                    getDatasetAtEvent={e => console.log(e)}
-                    />
-                </div>
+              <Element name="steps_graph">
+                <Card className="shadow">
+                <CardHeader className="bg-transparent">
+                    <Row className="align-items-center">
+                      <div className="col">
+                      <h6 className="text-uppercase text-muted ls-1 mb-1">
+                        Overview
+                      </h6>
+                      <h2 className="mb-0">Step Counts</h2>
+                      </div>
+                      <div className="col">
+                      <Nav className="justify-content-end" pills>
+                          <NavItem>
+                          <NavLink
+                              className={classnames("py-2 px-3", {
+                              active: this.state.activeNav6 === 1
+                              })}
+                              href="#pablo"
+                              onClick={e => this.toggleNavs(e, 2, 2, 1)}
+                              // onClick={e => e.preventDefault()}
+                              >
+                              <span className="d-none d-md-block">Week</span>
+                              <span className="d-md-none">W</span>
+                          </NavLink>
+                          </NavItem>
+                          <NavItem>
+                          <NavLink
+                              className={classnames("py-2 px-3", {
+                              active: this.state.activeNav6 === 2
+                              })}
+                              href="#pablo"
+                              onClick={e => this.toggleNavs(e, 2, 2, 2)}
+                              // onClick={e => e.preventDefault()}
+                              >
+                              <span className="d-none d-md-block">Month</span>
+                              <span className="d-md-none">M</span>
+                          </NavLink>
+                          </NavItem>
+                      </Nav>
+                      </div>
+                    </Row>
+                </CardHeader>
+                <CardBody>
+                  {/* Chart */}
+                  <div className="chart">
+                      <Bar
+                      data={chartExample6[this.state.chartExample6Data]}
+                      options={chartExample6.options}
+                      getDatasetAtEvent={e => console.log(e)}
+                      />
+                  </div>
                 </CardBody>
-              </Card>
+                </Card>
+              </Element>
             </Col>
           </Row>
           {/*Third Row */}
           <Row className="mt-5">
             <Col className="mb-5 mb-xl-0" xl="6">
-              <Card className="shadow">
-              <CardHeader className="bg-transparent">
-                  <Row className="align-items-center">
-                    <div className="col">
-                    <h6 className="text-uppercase text-muted ls-1 mb-1">
-                      Overview
-                    </h6>
-                    <h2 className="mb-0">Social Activities (minutes)</h2>
-                    </div>
-                    <div className="col">
-                    <Nav className="justify-content-end" pills>
-                        <NavItem>
-                        <NavLink
-                            className={classnames("py-2 px-3", {
-                            active: this.state.activeNav3 === 1
-                            })}
-                            href="#pablo"
-                            onClick={e => this.toggleNavs(e, 3, 1, 1)}
-                            // onClick={e => e.preventDefault()}
-                            >
-                            <span className="d-none d-md-block">Day</span>
-                            <span className="d-md-none">D</span>
-                        </NavLink>
-                        </NavItem>
-                        <NavItem>
-                        <NavLink
-                            className={classnames("py-2 px-3", {
-                            active: this.state.activeNav3 === 2
-                            })}
-                            href="#pablo"
-                            onClick={e => this.toggleNavs(e, 3, 1, 2)}
-                            // onClick={e => e.preventDefault()}
-                            >
-                            <span className="d-none d-md-block">Week</span>
-                            <span className="d-md-none">W</span>
-                        </NavLink>
-                        </NavItem>
-                        <NavItem>
-                        <NavLink
-                            className={classnames("py-2 px-3", {
-                            active: this.state.activeNav3 === 3
-                            })}
-                            href="#pablo"
-                            onClick={e => this.toggleNavs(e, 3, 1, 3)}
-                            // onClick={e => e.preventDefault()}
-                            >
-                            <span className="d-none d-md-block">Month</span>
-                            <span className="d-md-none">M</span>
-                        </NavLink>
-                        </NavItem>
-                    </Nav>
-                    </div>
-                  </Row>
-              </CardHeader>
-              <CardBody>
-                {/* Chart */}
-                <div className="chart">
-                    <Pie
-                    data={chartExample3[this.state.chartExample3Data]}
-                    options={chartExample3.options}
-                    getDatasetAtEvent={e => console.log(e)}
-                    />
-                </div>
-                </CardBody>
-              </Card>
+              <Element name="social_graph">
+                <Card className="shadow">
+                <CardHeader className="bg-transparent">
+                    <Row className="align-items-center">
+                      <div className="col">
+                      <h6 className="text-uppercase text-muted ls-1 mb-1">
+                        Overview
+                      </h6>
+                      <h2 className="mb-0">Social Activities (minutes)</h2>
+                      </div>
+                      <div className="col">
+                      <Nav className="justify-content-end" pills>
+                          <NavItem>
+                          <NavLink
+                              className={classnames("py-2 px-3", {
+                              active: this.state.activeNav3 === 1
+                              })}
+                              href="#pablo"
+                              onClick={e => this.toggleNavs(e, 3, 1, 1)}
+                              // onClick={e => e.preventDefault()}
+                              >
+                              <span className="d-none d-md-block">Day</span>
+                              <span className="d-md-none">D</span>
+                          </NavLink>
+                          </NavItem>
+                          <NavItem>
+                          <NavLink
+                              className={classnames("py-2 px-3", {
+                              active: this.state.activeNav3 === 2
+                              })}
+                              href="#pablo"
+                              onClick={e => this.toggleNavs(e, 3, 1, 2)}
+                              // onClick={e => e.preventDefault()}
+                              >
+                              <span className="d-none d-md-block">Week</span>
+                              <span className="d-md-none">W</span>
+                          </NavLink>
+                          </NavItem>
+                          <NavItem>
+                          <NavLink
+                              className={classnames("py-2 px-3", {
+                              active: this.state.activeNav3 === 3
+                              })}
+                              href="#pablo"
+                              onClick={e => this.toggleNavs(e, 3, 1, 3)}
+                              // onClick={e => e.preventDefault()}
+                              >
+                              <span className="d-none d-md-block">Month</span>
+                              <span className="d-md-none">M</span>
+                          </NavLink>
+                          </NavItem>
+                      </Nav>
+                      </div>
+                    </Row>
+                </CardHeader>
+                <CardBody>
+                  {/* Chart */}
+                  <div className="chart">
+                      <Pie
+                      data={chartExample3[this.state.chartExample3Data]}
+                      options={chartExample3.options}
+                      getDatasetAtEvent={e => console.log(e)}
+                      />
+                  </div>
+                  </CardBody>
+                </Card>
+              </Element>
             </Col>
 
           </Row>


### PR DESCRIPTION
This PR solves these issues:

* The icons in the top right corners of the summary cards don't automatically lead you to the appropriate graph below when you click on them.
* Day/Week/Month stamp: nothing tells us which day, week, month we're in and  there is no consistency in duration for each measure (i.e. you can look at monthly step counts, but not monthly social activity)
* Menu at top left: "chart" item takes us to "stress Management" which should be removed  
* Profile information: do we need work title, place of work, and address? We'd like to be mindful about collecting personal info
* Top right: "settings" and "my profile" lead to the same place